### PR TITLE
better names, more core primitives, exponential backoff

### DIFF
--- a/core/shared/src/main/scala/scalaz/zio/Fiber.scala
+++ b/core/shared/src/main/scala/scalaz/zio/Fiber.scala
@@ -53,6 +53,25 @@ trait Fiber[+E, +A] { self =>
     }
 
   /**
+   * Zips this fiber and the specified fiber togther, producing a tuple of their
+   * output.
+   */
+  final def zip[E1 >: E, B](that: => Fiber[E1, B]): Fiber[E1, (A, B)] =
+    zipWith(that)((a, b) => (a, b))
+
+  /**
+   * Same as `zip` but discards the output of the left hand side.
+   */
+  final def *>[E1 >: E, B](that: Fiber[E1, B]): Fiber[E1, B] =
+    zip(that).map(_._2)
+
+  /**
+   * Same as `zip` but discards the output of the right hand side.
+   */
+  final def <*[E1 >: E, B](that: Fiber[E1, B]): Fiber[E1, A] =
+    zip(that).map(_._1)
+
+  /**
    * Maps over the value the Fiber computes.
    */
   final def map[B](f: A => B): Fiber[E, B] =

--- a/core/shared/src/main/scala/scalaz/zio/IO.scala
+++ b/core/shared/src/main/scala/scalaz/zio/IO.scala
@@ -156,11 +156,19 @@ sealed abstract class IO[+E, +A] { self =>
   /**
    * Races this action with the specified action, returning the first
    * result to produce an `A`, whichever it is. If neither action succeeds,
-   * then the action will be terminated with some error.
+   * then the action will fail with some error.
    */
   final def race[E1 >: E, A1 >: A](that: IO[E1, A1]): IO[E1, A1] =
-    raceWith(that)((a, fiber) => fiber.interrupt(LostRace(Right(fiber))).const(a),
-                   (a, fiber) => fiber.interrupt(LostRace(Left(fiber))).const(a))
+    raceBoth(that).map(_.merge)
+
+  /**
+   * Races this action with the specified action, returning the first
+   * result to produce a value, whichever it is. If neither action succeeds,
+   * then the action will fail with some error.
+   */
+  final def raceBoth[E1 >: E, B](that: IO[E1, B]): IO[E1, Either[A, B]] =
+    raceWith(that)((a, fiber) => fiber.interrupt(LostRace(Right(fiber))).const(Left(a)),
+                   (b, fiber) => fiber.interrupt(LostRace(Left(fiber))).const(Right(b)))
 
   /**
    * Races this action with the specified action, invoking the

--- a/core/shared/src/main/scala/scalaz/zio/Retry.scala
+++ b/core/shared/src/main/scala/scalaz/zio/Retry.scala
@@ -203,6 +203,12 @@ trait Retry[E, +S] { self =>
     }
 
   /**
+   * A named version of the `<||>` operator.
+   */
+  final def andThen[S2](that0: => Retry[E, S2]): Retry[E, Either[S, S2]] =
+    self <||> that0
+
+  /**
    * Returns a new retry strategy with the state transformed by the specified
    * function.
    */


### PR DESCRIPTION
@ktonga Implemented what I _think_ are all the combinators necessary to replace the ad hoc list of retry methods in `IO`.